### PR TITLE
Update range proof to match the paper

### DIFF
--- a/src/zkproofs/range_proof.rs
+++ b/src/zkproofs/range_proof.rs
@@ -230,19 +230,19 @@ impl RangeProof {
                         w2: data.w2[i].clone(),
                         r2: data.r2[i].clone(),
                     }
-                } else if secret_x + &data.w1[i] > range_scaled_third
-                    && secret_x + &data.w1[i] < range_scaled_two_thirds
+                } else if secret_x + &data.w1[i] >= range_scaled_third
+                    && secret_x + &data.w1[i] <= range_scaled_two_thirds
                 {
                     Response::Mask {
                         j: 1,
                         masked_x: secret_x + &data.w1[i],
-                        masked_r: secret_r * &data.r1[i] % &ek.n,
+                        masked_r: (secret_r * &data.r1[i]) % &ek.n,
                     }
                 } else {
                     Response::Mask {
                         j: 2,
                         masked_x: secret_x + &data.w2[i],
-                        masked_r: secret_r * &data.r2[i] % &ek.n,
+                        masked_r: (secret_r * &data.r2[i]) % &ek.n,
                     }
                 }
             })
@@ -297,12 +297,14 @@ impl RangeProof {
                             res = false;
                         }
 
-                        let flag = (*w2 < range_scaled_third
-                            && *w1 > range_scaled_third
-                            && *w1 < range_scaled_two_thirds)
-                            || (*w1 < range_scaled_third
-                                && *w2 > range_scaled_third
-                                && *w2 < range_scaled_two_thirds);
+                        let flag = (*w2 >= BigInt::zero()
+                            && *w2 <= range_scaled_third
+                            && *w1 >= range_scaled_third
+                            && *w1 <= range_scaled_two_thirds)
+                            || (*w1 >= BigInt::zero()
+                                && *w1 <= range_scaled_third
+                                && *w2 >= range_scaled_third
+                                && *w2 <= range_scaled_two_thirds);
 
                         if !flag {
                             res = false;

--- a/src/zkproofs/range_proof.rs
+++ b/src/zkproofs/range_proof.rs
@@ -476,6 +476,57 @@ mod tests {
     }
 
     #[test]
+    fn test_range_proof_correct_proof_for_small_range_many_times() {
+        for _ in 0..100 {
+            // common:
+            let range = BigInt::from(6000);
+            // prover:
+            let (ek, _dk) = test_keypair().keys();
+            let (verifier_ek, verifier_dk) = test_keypair().keys();
+            // verifier:
+            let (com, r, e) = RangeProof::verifier_commit(&verifier_ek);
+            let (challenge, verification_aid) = CorrectKey::challenge(&verifier_ek);
+            let proof_results = CorrectKey::prove(&verifier_dk, &challenge);
+            let _result = CorrectKey::verify(&proof_results.unwrap(), &verification_aid);
+            assert!(RangeProof::verify_commit(&verifier_ek, &com, &r, &e).is_ok());
+            // prover:
+            let (encrypted_pairs, data_and_randmoness_pairs) =
+                RangeProof::generate_encrypted_pairs(&ek, &range, STATISTICAL_ERROR_FACTOR);
+            // prover:
+            let secret_r = BigInt::sample_below(&ek.n);
+            let secret_x = BigInt::sample_below(&range.div_floor(&BigInt::from(3)));
+            // common:
+            let cipher_x = Paillier::encrypt_with_chosen_randomness(
+                &ek,
+                RawPlaintext::from(&secret_x),
+                &Randomness(secret_r.clone()),
+            );
+            // verifer decommits (tested in test_commit_decommit)
+            // prover:
+            let z_vector = RangeProof::generate_proof(
+                &ek,
+                &secret_x,
+                &secret_r,
+                &e,
+                &range,
+                &data_and_randmoness_pairs,
+                STATISTICAL_ERROR_FACTOR,
+            );
+            // verifier:
+            let result = RangeProof::verifier_output(
+                &ek,
+                &e,
+                &encrypted_pairs,
+                &z_vector,
+                &range,
+                &cipher_x.0,
+                STATISTICAL_ERROR_FACTOR,
+            );
+            assert!(result.is_ok());
+        }
+    }
+
+    #[test]
     fn test_range_proof_incorrect_proof() {
         // common:
         let range = BigInt::sample(RANGE_BITS);

--- a/src/zkproofs/range_proof_ni.rs
+++ b/src/zkproofs/range_proof_ni.rs
@@ -177,6 +177,23 @@ mod tests {
     }
 
     #[test]
+    fn test_verifier_for_correct_proofs_for_small_range_many_times() {
+        for _ in 0..100 {
+            let (ek, _dk) = test_keypair().keys();
+            let range = BigInt::sample(6000);
+            let secret_r = BigInt::sample_below(&ek.n);
+            let secret_x = BigInt::sample_below(&range.div_floor(&BigInt::from(3)));
+            let cipher_x = Paillier::encrypt_with_chosen_randomness(
+                &ek,
+                RawPlaintext::from(&secret_x),
+                &Randomness(secret_r.clone()),
+            );
+            let range_proof = RangeProofNi::prove(&ek, &range, &cipher_x.0, &secret_x, &secret_r);
+            range_proof.verify(&ek, &cipher_x.0).unwrap();
+        }
+    }
+
+    #[test]
     #[should_panic]
     fn test_verifier_for_incorrect_proof() {
         let (ek, _dk) = test_keypair().keys();


### PR DESCRIPTION
While investigating #25, I found that some bounds check is inclusive in the [paper], and exclusive in implementation. I fixed this, and test from #25 has never failed again.

Fixes #25 

[paper]: https://eprint.iacr.org/2017/552.pdf